### PR TITLE
Fix GitHub capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Node-RED nodes to communicate with GramJS
 
 <p align="center">
-<img alt="Github issues" src="https://img.shields.io/github/issues/patricktobias86/node-red-telegram-account?color=56BEB8" />
-<img alt="Github forks" src="https://img.shields.io/github/forks/patricktobias86/node-red-telegram-account?color=56BEB8" />
-<img alt="Github stars" src="https://img.shields.io/github/stars/patricktobias86/node-red-telegram-account?color=56BEB8" />
+<img alt="GitHub issues" src="https://img.shields.io/github/issues/patricktobias86/node-red-telegram-account?color=56BEB8" />
+<img alt="GitHub forks" src="https://img.shields.io/github/forks/patricktobias86/node-red-telegram-account?color=56BEB8" />
+<img alt="GitHub stars" src="https://img.shields.io/github/stars/patricktobias86/node-red-telegram-account?color=56BEB8" />
 </p>
 
 ```bash


### PR DESCRIPTION
## Summary
- update GitHub shield alt text in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c197684dc8320bf10632cd74e44f1