### PR TITLE
Fix topMsgId property in send-message node

### DIFF
--- a/nodes/send-message.js
+++ b/nodes/send-message.js
@@ -48,7 +48,7 @@ module.exports = function (RED) {
                     supportStreaming: supportStreaming,
                     noforwards: noforwards,
                     commentTo: commentTo !== "" ? commentTo : undefined,
-                    topMsgId: topMsgId !== topMsgId ? commentTo : undefined,
+                    topMsgId: topMsgId !== "" ? topMsgId : undefined,
                 };
 
                 if (schedule) {


### PR DESCRIPTION
## Summary
- correct `topMsgId` assignment in `send-message.js`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c19b249f88320a3fbf8a068dd6757