### PR TITLE
Fix Chat ID label

### DIFF
--- a/nodes/send-message.html
+++ b/nodes/send-message.html
@@ -102,7 +102,7 @@
     </div>
   
     <div class="form-row">
-      <label for="node-input-chat_id">
+      <label for="node-input-chatId">
         <i class="fa fa-user"></i> Chat ID
       </label>
       <input type="text" id="node-input-chatId" placeholder="Peer ID">


### PR DESCRIPTION
## Summary
- fix send-message label `for` attribute so it matches the input id

## Testing
- `npm test` *(fails: missing script)*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c19d30d68832082511a4377635ed2