### PR TITLE
Add resolve-userid node

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,8 @@
 ```bash
 npm i @patricktobias86/node-red-telegram-account
 ```
+
+## Nodes
+
+- resolve-userid – resolve a Telegram username to its numeric user ID
+

--- a/nodes/resolve-userid.html
+++ b/nodes/resolve-userid.html
@@ -1,0 +1,56 @@
+<script type="text/javascript">
+    RED.nodes.registerType('resolve-userid', {
+        category: 'telegram-account',
+        color: '#229ED9',
+        icon: 'tg.png',
+        align: 'right',
+        defaults: {
+            name: { value: '' },
+            config: { type: 'config', required: false },
+            username: { value: '' }
+        },
+        inputs: 1,
+        outputs: 1,
+        paletteLabel: 'resolve userid',
+        label: function() {
+            return this.name||'resolve userid';
+        }
+    });
+</script>
+
+<script type="text/html" data-template-name="resolve-userid">
+    <div class="form-row">
+        <label for="node-input-name">
+            <i class="fa fa-tag"></i> Name
+        </label>
+        <input type="text" id="node-input-name" placeholder="Name" style="width: 60%" />
+    </div>
+    <div class="form-row">
+        <label for="node-input-config">
+            <i class="fa fa-gear"></i> Config
+        </label>
+        <input type="text" id="node-input-config" placeholder="Config" style="width: 60%" />
+    </div>
+    <div class="form-row">
+        <label for="node-input-username">
+            <i class="fa fa-user"></i> Username
+        </label>
+        <input type="text" id="node-input-username" placeholder="@username" style="width: 60%" />
+    </div>
+</script>
+
+<script type="text/html" data-help-name="resolve-userid">
+    <p>The <b>resolve-userid</b> node converts a Telegram username into a numeric user ID.</p>
+    <h3>Inputs</h3>
+    <dl class="message-properties">
+        <dt>payload.username <span class="property-type">string</span></dt>
+        <dd>The Telegram username to resolve, e.g., <code>@someuser</code>.</dd>
+        <dt>payload.client <span class="property-type">object</span></dt>
+        <dd>Optional Telegram client instance. If omitted, the client from the configuration node is used.</dd>
+    </dl>
+    <h3>Outputs</h3>
+    <dl class="message-properties">
+        <dt>payload.userId <span class="property-type">number | bigint</span></dt>
+        <dd>The resolved Telegram user ID, or <code>null</code> if resolution fails.</dd>
+    </dl>
+</script>

--- a/nodes/resolve-userid.js
+++ b/nodes/resolve-userid.js
@@ -1,0 +1,36 @@
+module.exports = function(RED) {
+    function ResolveUserId(config) {
+        RED.nodes.createNode(this, config);
+        this.config = RED.nodes.getNode(config.config);
+        var node = this;
+
+        this.on('input', async function(msg) {
+            const username = msg.payload?.username || config.username;
+            const client = msg.payload?.client ? msg.payload.client : node.config?.client;
+
+            if (!username) {
+                node.error('No username provided');
+                return;
+            }
+            if (!client) {
+                node.error('Telegram client not configured');
+                return;
+            }
+
+            try {
+                const entity = await client.getEntity(username);
+                let userId;
+                if (entity?.id) {
+                    userId = entity.id;
+                } else if (entity?.userId) {
+                    userId = entity.userId;
+                }
+                node.send({ payload: { userId } });
+            } catch (err) {
+                node.error('Error resolving username: ' + err.message);
+                node.send({ payload: { userId: null } });
+            }
+        });
+    }
+    RED.nodes.registerType('resolve-userid', ResolveUserId);
+};

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
       "telegram-account-delete-message": "nodes/delete-message.js",
       "telegram-account-iter-dialog": "nodes/iter-dialogs.js",
       "telegram-account-iter-messages": "nodes/iter-messages.js",
-      "telegram-account-promote-admin": "nodes/promote-admin.js"
+      "telegram-account-promote-admin": "nodes/promote-admin.js",
+      "telegram-account-resolve-userid": "nodes/resolve-userid.js"
     }
   },
   "publishConfig": {


### PR DESCRIPTION
## Summary
- add a resolve-userid node to map usernames to numeric user IDs
- document the new node in the README

## Testing
- `npm pack`

------
https://chatgpt.com/codex/tasks/task_e_685c07d223388320969d7e497e2927e2