### PR TITLE
Improve config client caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,6 @@ See [docs/NODES.md](docs/NODES.md) for a detailed description of every node. Bel
 
 ## Session management
 
-Connections to Telegram are cached by the configuration node. When the flow is redeployed, the existing session is reused instead of creating a new one. The client is only disconnected once no nodes reference that session anymore.
+Connections to Telegram are cached by the configuration node. A Map keyed by the `stringSession` tracks each client together with a reference count and the connection promise. If a node is created while another one is still connecting, it waits for that promise and then reuses the same client. The client is disconnected only once no nodes reference that session anymore.
 
 Example flows can be found in the [examples](examples) folder.

--- a/docs/NODES.md
+++ b/docs/NODES.md
@@ -6,7 +6,7 @@ Below is a short description of each node. For a full list of configuration opti
 
 | Node | Description |
 |------|-------------|
-| **config** | Configuration node storing API credentials and connection options. Other nodes reference this to share a Telegram client and reuse the session. |
+| **config** | Configuration node storing API credentials and connection options. Other nodes reference this to share a Telegram client and reuse the session. Connections are tracked in a Map with a reference count so multiple nodes can wait for the same connection. |
 | **auth** | Starts an interactive login flow. Produces a `stringSession` that can be reused with the `config` node. |
 | **receiver** | Emits an output message for every incoming Telegram message. Can ignore specific user IDs. |
 | **command** | Listens for new messages and triggers when a message matches a configured command or regular expression. |


### PR DESCRIPTION
## Summary
- cache clients in a `Map` instead of plain object
- keep connection promise and ref count in cache entries
- update session management docs

## Testing
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687f20f4f0788330a7d50ba7c1183abb