### PR TITLE
Expand session caching docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ See [docs/NODES.md](docs/NODES.md) for a detailed description of every node. Bel
 
 ## Session management
 
-Connections to Telegram are cached by the configuration node. A Map keyed by the `stringSession` tracks each client together with a reference count and the connection promise. If a node is created while another one is still connecting, it waits for that promise and then reuses the same client. The client is disconnected only once no nodes reference that session anymore.
+Connections to Telegram are cached by the configuration node. A Map keyed by the `stringSession` tracks each client together with a reference count and the connection promise. If a node is created while another one is still connecting, it waits for that promise and then reuses the same client.
+
+A single `TelegramClient` instance is therefore shared between all flows that point to the same configuration node, even after a redeploy. When Node‑RED restarts it checks the cache and returns the existing client rather than creating a new connection. The reference count is decreased whenever a node using the session is closed. Once all nodes have closed and the count reaches zero, the cached client is disconnected.
 
 Example flows can be found in the [examples](examples) folder.
 


### PR DESCRIPTION
## Summary
- clarify that connection caching reuses a single Telegram client across flows and redeploys
- explain that disconnect occurs once all nodes close

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687f5ff619488330b056ec42640504d0