### PR TITLE
Release 1.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [1.1.7] - 2025-07-22
+### Added
+- Mocha tests for the configuration node ensure sessions are reused correctly.
+
+### Changed
+- Session management now tracks active clients in a `Map` for safer reuse.
+

--- a/README.md
+++ b/README.md
@@ -45,3 +45,7 @@ npm test
 ```
 
 The tests use Mocha and verify that sessions are properly cached across nodes.
+
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for release notes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@patricktobias86/node-red-telegram-account",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@patricktobias86/node-red-telegram-account",
-      "version": "1.1.6",
+      "version": "1.1.7",
       "license": "MIT",
       "dependencies": {
         "telegram": "^2.17.10"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patricktobias86/node-red-telegram-account",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Node-RED nodes to communicate with GramJS.",
   "main": "nodes/config.js",
   "keywords": [


### PR DESCRIPTION
## Summary
- bump version to 1.1.7
- add changelog highlighting session management improvements and tests
- link changelog from README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687f601a87408330b6a43396e3f8e7c7