### PR TITLE
Add debug option to all nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ See [docs/NODES.md](docs/NODES.md) for a detailed description of every node. Bel
 - **promote-admin** – promotes a user to admin with configurable rights.
 - **resolve-userid** – converts a username to a numeric user ID.
 
+All nodes include a <code>Debug</code> option that logs incoming and outgoing messages to the Node-RED log when enabled.
+
 ## Session management
 
 Connections to Telegram are cached by the configuration node. A Map keyed by the `stringSession` tracks each client together with a reference count and the connection promise. If a node is created while another one is still connecting, it waits for that promise and then reuses the same client.

--- a/docs/NODES.md
+++ b/docs/NODES.md
@@ -20,3 +20,5 @@ Below is a short description of each node. For a full list of configuration opti
 | **resolve-userid** | Converts a Telegram username to its numeric user ID. |
 
 
+All nodes provide a **Debug** checkbox. When enabled the node will log its input and output messages to aid troubleshooting.
+

--- a/nodes/auth.html
+++ b/nodes/auth.html
@@ -7,7 +7,8 @@
             api_id: { value: "" },
             api_hash: { value: "" },
             phoneNumber: { value: "" },
-            password: { value: "" }
+            password: { value: "" },
+            debug: { value: false }
         },
         inputs: 1,
         outputs: 1,
@@ -70,6 +71,12 @@
     </label>
     <input type="password" id="node-input-password" placeholder="Enter your password (if any)">
 </div>
+<div class="form-row">
+    <label for="node-input-debug">
+        <i class="fa fa-bug"></i> Debug
+    </label>
+    <input type="checkbox" id="node-input-debug">
+</div>
 
 <p>
     <strong>Note:</strong> These values are used to create a Telegram session string.
@@ -78,6 +85,7 @@
 
 <script type="text/html" data-help-name="auth">
     <p>The <b>auth</b> node facilitates Telegram API authentication using the <code>telegram</code> (GramJS) library. It allows users to authenticate a session and retrieve a <code>stringSession</code> for reuse with other Telegram clients.</p>
+    <p>Enable <b>Debug</b> to log the incoming credentials and returned session.</p>
 
     <h3>Inputs</h3>
     <dl class="message-properties">

--- a/nodes/command.html
+++ b/nodes/command.html
@@ -7,7 +7,8 @@
         name: { value: '' },
         config: { type: 'config', required: false },
         command: { value: "", required: true },
-        regex: { value: false }
+        regex: { value: false },
+        debug: { value: false }
       },
       inputs: 1,
       outputs: 1,
@@ -41,6 +42,12 @@
         style="width: 60%"
       />
     </div>
+    <div class="form-row">
+      <label for="node-input-debug">
+        <i class="fa fa-bug"></i> Debug
+      </label>
+      <input type="checkbox" id="node-input-debug">
+    </div>
 
     <div class="form-row">
         <label for="node-input-command">
@@ -57,8 +64,9 @@
     </div>
   </script>
 
-  <script type="text/html" data-help-name="command">
+<script type="text/html" data-help-name="command">
     <p>The <b>command</b> node listens for specific commands or patterns in Telegram messages and triggers further processing when a match is found. It supports both exact matches and regex-based pattern matching.</p>
+    <p>Enable <b>Debug</b> to log matching updates and outputs.</p>
 
     <h3>Inputs</h3>
     <p>This node does not take any direct inputs. Instead, it listens for incoming messages from the Telegram bot or user.</p>

--- a/nodes/command.js
+++ b/nodes/command.js
@@ -5,13 +5,18 @@ module.exports = function (RED) {
   function Command(config) {
     RED.nodes.createNode(this, config);
     this.config = RED.nodes.getNode(config.config);
+    this.debugEnabled = config.debug;
     var node = this;
     /** @type {TelegramClient} */
     const client =  this.config.client;
 
     const event = new NewMessage();
     const handler = (update) => {
+        const debug = node.debugEnabled;
         const message = update.message.message;
+        if (debug) {
+            node.log('command update: ' + JSON.stringify(update));
+        }
         if (message) {
             if (config.regex) {
                 const regex = new RegExp(config.command);
@@ -23,6 +28,9 @@ module.exports = function (RED) {
                         }
                     };
                     node.send(msg);
+                    if (debug) {
+                        node.log('command output: ' + JSON.stringify(msg));
+                    }
                 }
             } else if (message === config.command) {
                 var msg = {
@@ -31,6 +39,9 @@ module.exports = function (RED) {
                     }
                 };
                 node.send(msg);
+                if (debug) {
+                    node.log('command output: ' + JSON.stringify(msg));
+                }
             }
         }
     };

--- a/nodes/config.html
+++ b/nodes/config.html
@@ -6,6 +6,7 @@
           api_id: {value:"", required:true},
           api_hash: {value:"", required:true},
           session: {value:"", required:true},
+          debug: {value:false},
           useIPV6: {value: undefined},
           timeout: {value: undefined},
           requestRetries: {value: undefined},
@@ -51,6 +52,10 @@
   <div class="form-row">
       <label for="node-config-input-session"><i class="icon-tasks"></i> Session</label>
       <input type="text" id="node-config-input-session" placeholder="Enter Session" style="width:70%" ng-model="node.session">
+  </div>
+  <div class="form-row">
+      <label for="node-config-input-debug"><i class="icon-bug"></i> Debug</label>
+      <input type="checkbox" id="node-config-input-debug" ng-model="node.debug">
   </div>
   <div class="form-row">
       <label for="node-config-input-useIPV6"><i class="icon-tasks"></i> Use IPV6</label>

--- a/nodes/delete-message.html
+++ b/nodes/delete-message.html
@@ -7,6 +7,7 @@
         defaults: {
             name: { value: '' },
             config: { type: 'config', required: false },
+            debug: { value: false },
         },
         inputs: 1,
         outputs: 1,
@@ -40,11 +41,18 @@
         style="width: 60%"
       />
     </div>
+    <div class="form-row">
+      <label for="node-input-debug">
+        <i class="fa fa-bug"></i> Debug
+      </label>
+      <input type="checkbox" id="node-input-debug">
+    </div>
   </script>
 
 
-  <script type="text/html" data-help-name="delete-message">
+<script type="text/html" data-help-name="delete-message">
     <p>The <b>delete-message</b> node allows you to delete messages from a Telegram chat. It supports deleting multiple messages at once and provides an option to revoke messages for all chat participants.</p>
+    <p>Enable <b>Debug</b> to log the input and output.</p>
 
     <h3>Inputs</h3>
     <dl class="message-properties">

--- a/nodes/delete-message.js
+++ b/nodes/delete-message.js
@@ -2,9 +2,14 @@ module.exports = function (RED) {
     function DeleteMessage(config) {
         RED.nodes.createNode(this, config);
         this.config = RED.nodes.getNode(config.config);
+        this.debugEnabled = config.debug;
         var node = this;
 
         this.on('input', async function (msg) {
+            const debug = node.debugEnabled || msg.debug;
+            if (debug) {
+                node.log('delete-message input: ' + JSON.stringify(msg));
+            }
             const chatId = msg.payload.chatId || config.chatId;
             const messageIds = msg.payload.messageIds || config.messageIds;
             const revoke = msg.payload.revoke || config.revoke || { revoke: true };
@@ -14,9 +19,11 @@ module.exports = function (RED) {
             try {
                 const response = await client.deleteMessages(chatId, messageIds, revoke);
 
-                node.send({
-                    payload: response,
-                });
+                const out = { payload: response };
+                node.send(out);
+                if (debug) {
+                    node.log('delete-message output: ' + JSON.stringify(out));
+                }
             } catch (err) {
                 node.error('Error deleting message: ' + err.message);
             }

--- a/nodes/get-entity.html
+++ b/nodes/get-entity.html
@@ -7,6 +7,7 @@
         defaults: {
             name: { value: '' },
             config: { type: 'config', required: false },
+            debug: { value: false },
         },
         inputs: 1,
         outputs: 1,
@@ -40,10 +41,17 @@
             style="width: 60%"
         />
     </div>
+    <div class="form-row">
+        <label for="node-input-debug">
+            <i class="fa fa-bug"></i> Debug
+        </label>
+        <input type="checkbox" id="node-input-debug" />
+    </div>
 </script>
 
 <script type="text/html" data-help-name="get-entity">
     <p>The <b>get-entity</b> node retrieves information about a Telegram entity (e.g., user, chat, or channel) using its identifier or URL.</p>
+    <p>Enable <b>Debug</b> to print incoming and outgoing messages to the log.</p>
 
     <h3>Inputs</h3>
     <dl class="message-properties">

--- a/nodes/get-entity.js
+++ b/nodes/get-entity.js
@@ -2,9 +2,14 @@ module.exports = function (RED) {
     function GetEntity(config) {
         RED.nodes.createNode(this, config);
         this.config = RED.nodes.getNode(config.config);
+        this.debugEnabled = config.debug;
         var node = this;
 
         this.on('input', async function (msg) {
+            const debug = node.debugEnabled || msg.debug;
+            if (debug) {
+                node.log('get-entity input: ' + JSON.stringify(msg));
+            }
             const input = msg.payload.input || config.input;
               /** @type {TelegramClient} */
             const client = msg.payload?.client ? msg.payload.client : this.config.client;
@@ -20,14 +25,18 @@ module.exports = function (RED) {
                     entity = await client.getEntity(input);
                 }
 
-                node.send({
-                    payload: {input:entity},
-                });
+                const out = { payload: { input: entity } };
+                node.send(out);
+                if (debug) {
+                    node.log('get-entity output: ' + JSON.stringify(out));
+                }
             } catch (err) {
                 node.error('Error getting entity: ' + err.message);
-                node.send({
-                    payload:{ input: null}
-                })
+                const out = { payload: { input: null } };
+                node.send(out);
+                if (debug) {
+                    node.log('get-entity output: ' + JSON.stringify(out));
+                }
             }
         });
     }

--- a/nodes/iter-dialogs.html
+++ b/nodes/iter-dialogs.html
@@ -7,6 +7,7 @@
         defaults: {
             name: { value: '' },
             config: { type: 'config', required: true },
+            debug: { value: false },
             limit: { value: "" },
             offsetDate: { value: ""},
             offsetId: { value: "" },
@@ -48,6 +49,12 @@
             style="width: 60%"
             ng-model="config"
         />
+    </div>
+    <div class="form-row">
+        <label for="node-input-debug">
+            <i class="fa fa-bug"></i> Debug
+        </label>
+        <input type="checkbox" id="node-input-debug" ng-model="debug" />
     </div>
     <div class="form-row">
         <label for="node-input-limit">
@@ -131,6 +138,7 @@
 
 <script type="text/html" data-help-name="iter-dialogs">
     <p>The <b>iter-dialogs</b> node retrieves a list of Telegram dialogs (chats, channels, or groups) by iterating through them using the Telegram API.</p>
+    <p>Enable <b>Debug</b> to log the request and resulting dialogs.</p>
 
     <h3>Inputs</h3>
     <dl class="message-properties">

--- a/nodes/iter-dialogs.js
+++ b/nodes/iter-dialogs.js
@@ -4,9 +4,14 @@ module.exports = function (RED) {
     function IterDialogs(config) {
         RED.nodes.createNode(this, config);
         this.config = RED.nodes.getNode(config.config);
+        this.debugEnabled = config.debug;
         var node = this;
 
         this.on('input', async function (msg) {
+            const debug = node.debugEnabled || msg.debug;
+            if (debug) {
+                node.log('iter-dialogs input: ' + JSON.stringify(msg));
+            }
     
             /** @type {TelegramClient} */
             const client = msg.payload?.client ? msg.payload.client : this.config.client;
@@ -40,9 +45,11 @@ module.exports = function (RED) {
                     dialogs[dialog.id] = dialog;
                     console.log(`${dialog.id}: ${dialog.title}`);
                 }
-                node.send({
-                    payload: { dialogs },
-                });
+                const out = { payload: { dialogs } };
+                node.send(out);
+                if (debug) {
+                    node.log('iter-dialogs output: ' + JSON.stringify(out));
+                }
             } catch (err) {
                 node.error('Error iter dialogs: ' + err.message);
             }

--- a/nodes/iter-messages.html
+++ b/nodes/iter-messages.html
@@ -7,6 +7,7 @@
         defaults: {
             name: { value: '' },
             config: { type: 'config', required: true },
+            debug: { value: false },
             chatId: { value: '', required: false },
             limit: { value: '', required: false },
             offsetDate: { value: '', required: false },
@@ -67,6 +68,12 @@
             style="width: 60%"
             ng-model="config"
         />
+    </div>
+    <div class="form-row">
+        <label for="node-input-debug">
+            <i class="fa fa-bug"></i> Debug
+        </label>
+        <input type="checkbox" id="node-input-debug" ng-model="debug" />
     </div>
     <div class="form-row">
         <label for="node-input-chatId">
@@ -259,6 +266,7 @@
 
 <script type="text/html" data-help-name="iter-messages">
     <p>The <b>iter-messages</b> node retrieves messages from a specified chat or user using the Telegram API. It supports a wide range of filtering and pagination options, allowing for efficient message iteration.</p>
+    <p>When <b>Debug</b> is enabled, incoming parameters and results are logged.</p>
 
     <h3>Inputs</h3>
     <dl class="message-properties">

--- a/nodes/iter-messages.js
+++ b/nodes/iter-messages.js
@@ -4,9 +4,14 @@ module.exports = function (RED) {
     function IterMessages(config) {
         RED.nodes.createNode(this, config);
         this.config = RED.nodes.getNode(config.config);
+        this.debugEnabled = config.debug;
         var node = this;
 
         this.on('input', async function (msg) {
+            const debug = node.debugEnabled || msg.debug;
+            if (debug) {
+                node.log('iter-messages input: ' + JSON.stringify(msg));
+            }
     
             /** @type {TelegramClient} */
             const client = msg.payload?.client ? msg.payload.client : this.config.client;
@@ -80,9 +85,11 @@ module.exports = function (RED) {
                     }
                 }
                 
-                node.send({
-                    payload: { messages },
-                });
+                const out = { payload: { messages } };
+                node.send(out);
+                if (debug) {
+                    node.log('iter-messages output: ' + JSON.stringify(out));
+                }
             } catch (err) {
                 node.error('Error iter messages: ' + err.message);
             }

--- a/nodes/promote-admin.html
+++ b/nodes/promote-admin.html
@@ -7,6 +7,7 @@
         defaults: {
             name: { value: '' },
             config: { type: 'config', required: false },
+            debug: { value: false },
             chatId: { value: '' },
             userId: { value: '' },
             rank: { value: 'admin' },
@@ -42,6 +43,10 @@
     <div class="form-row">
         <label for="node-input-config"><i class="fa fa-gear"></i> Config</label>
         <input type="hidden" id="node-input-config">
+    </div>
+    <div class="form-row">
+        <label for="node-input-debug"><i class="fa fa-bug"></i> Debug</label>
+        <input type="checkbox" id="node-input-debug">
     </div>
 
     <div class="form-row">
@@ -193,6 +198,7 @@
 </script>
 <script type="text/html" data-help-name="promote-admin">
     <p><b>Promote Admin</b> lets you promote a user to admin in a Telegram group or channel using the Telegram MTProto API (via GramJS).</p>
+    <p>With <b>Debug</b> enabled the node logs its request and the response from Telegram.</p>
 
     <h3>Inputs</h3>
     <dl class="message-properties">

--- a/nodes/promote-admin.js
+++ b/nodes/promote-admin.js
@@ -6,9 +6,14 @@ module.exports = function (RED) {
     function PromoteAdmin(config) {
         RED.nodes.createNode(this, config);
         this.config = RED.nodes.getNode(config.config);
+        this.debugEnabled = config.debug;
         var node = this;
 
         this.on('input', async function (msg) {
+            const debug = node.debugEnabled || msg.debug;
+            if (debug) {
+                node.log('promote-admin input: ' + JSON.stringify(msg));
+            }
             const client = msg.payload?.client || this.config.client;
             const chatId = msg.payload.chatId || config.chatId;
             const userId = msg.payload.userId || config.userId;
@@ -39,7 +44,11 @@ module.exports = function (RED) {
                     rank: rank,
                 }));
 
-                node.send({ payload: { response: result } });
+                const out = { payload: { response: result } };
+                node.send(out);
+                if (debug) {
+                    node.log('promote-admin output: ' + JSON.stringify(out));
+                }
             } catch (err) {
                 node.error("Error promoting admin: " + err.message);
             }

--- a/nodes/receiver.html
+++ b/nodes/receiver.html
@@ -6,7 +6,8 @@
         defaults: {
             name: { value: '' },
             config: { type: 'config', required: false },
-            ignore: { value:""}
+            ignore: { value:""},
+            debug: { value: false }
         },
         inputs: 1,
         outputs: 1,
@@ -41,6 +42,12 @@
       />
     </div>
     <div class="form-row">
+      <label for="node-input-debug">
+        <i class="fa fa-bug"></i> Debug
+      </label>
+      <input type="checkbox" id="node-input-debug">
+    </div>
+    <div class="form-row">
       <label for="node-input-ignore">
         <i class="fa fa-tag"></i> Config
       </label>
@@ -53,8 +60,9 @@
     </div>
   </script>
 
-  <script type="text/html" data-help-name="receiver">
+<script type="text/html" data-help-name="receiver">
     <p>The <b>receiver</b> node listens for incoming Telegram messages and forwards them as output messages in Node-RED. It supports filtering messages based on sender IDs to ignore specific users.</p>
+    <p>Turn on <b>Debug</b> to log received updates and the emitted messages.</p>
 
     <h3>Inputs</h3>
     <p>This node does not take any direct inputs. It listens to all incoming messages from the configured Telegram client.</p>

--- a/nodes/receiver.js
+++ b/nodes/receiver.js
@@ -4,18 +4,23 @@ module.exports = function (RED) {
   function Receiver(config) {
     RED.nodes.createNode(this, config);
     this.config = RED.nodes.getNode(config.config);
+    this.debugEnabled = config.debug;
     var node = this;
     const client =  this.config.client;
     const ignore = config.ignore.split(/\n/);
 
     const event = new NewMessage();
     const handler = (update) => {
+        const debug = node.debugEnabled;
+        if (debug) {
+            node.log('receiver update: ' + JSON.stringify(update));
+        }
         if (update.message.fromId != null && !ignore.includes(update.message.fromId.userId.toString())) {
-            node.send({
-                payload: {
-                    update
-                }
-            });
+            const out = { payload: { update } };
+            node.send(out);
+            if (debug) {
+                node.log('receiver output: ' + JSON.stringify(out));
+            }
         }
     };
 

--- a/nodes/resolve-userid.html
+++ b/nodes/resolve-userid.html
@@ -7,7 +7,8 @@
         defaults: {
             name: { value: '' },
             config: { type: 'config', required: false },
-            username: { value: '' }
+            username: { value: '' },
+            debug: { value: false }
         },
         inputs: 1,
         outputs: 1,
@@ -25,11 +26,17 @@
         </label>
         <input type="text" id="node-input-name" placeholder="Name" style="width: 60%" />
     </div>
+   <div class="form-row">
+       <label for="node-input-config">
+           <i class="fa fa-gear"></i> Config
+       </label>
+       <input type="text" id="node-input-config" placeholder="Config" style="width: 60%" />
+   </div>
     <div class="form-row">
-        <label for="node-input-config">
-            <i class="fa fa-gear"></i> Config
+        <label for="node-input-debug">
+            <i class="fa fa-bug"></i> Debug
         </label>
-        <input type="text" id="node-input-config" placeholder="Config" style="width: 60%" />
+        <input type="checkbox" id="node-input-debug" />
     </div>
     <div class="form-row">
         <label for="node-input-username">
@@ -41,6 +48,7 @@
 
 <script type="text/html" data-help-name="resolve-userid">
     <p>The <b>resolve-userid</b> node converts a Telegram username into a numeric user ID.</p>
+    <p>Select <b>Debug</b> to log lookups and results.</p>
     <h3>Inputs</h3>
     <dl class="message-properties">
         <dt>payload.username <span class="property-type">string</span></dt>

--- a/nodes/resolve-userid.js
+++ b/nodes/resolve-userid.js
@@ -2,9 +2,14 @@ module.exports = function(RED) {
     function ResolveUserId(config) {
         RED.nodes.createNode(this, config);
         this.config = RED.nodes.getNode(config.config);
+        this.debugEnabled = config.debug;
         var node = this;
 
         this.on('input', async function(msg) {
+            const debug = node.debugEnabled || msg.debug;
+            if (debug) {
+                node.log('resolve-userid input: ' + JSON.stringify(msg));
+            }
             const username = msg.payload?.username || config.username;
             const client = msg.payload?.client ? msg.payload.client : node.config?.client;
 
@@ -25,10 +30,18 @@ module.exports = function(RED) {
                 } else if (entity?.userId) {
                     userId = entity.userId;
                 }
-                node.send({ payload: { userId } });
+                const out = { payload: { userId } };
+                node.send(out);
+                if (debug) {
+                    node.log('resolve-userid output: ' + JSON.stringify(out));
+                }
             } catch (err) {
                 node.error('Error resolving username: ' + err.message);
-                node.send({ payload: { userId: null } });
+                const out = { payload: { userId: null } };
+                node.send(out);
+                if (debug) {
+                    node.log('resolve-userid output: ' + JSON.stringify(out));
+                }
             }
         });
     }

--- a/nodes/send-file.html
+++ b/nodes/send-file.html
@@ -6,6 +6,7 @@
             name: { value: '' },
             config: { type: 'config', required: true },
             chatId: { value: '', required: true },
+            debug: { value: false },
             files: { value: '', required: true },
             caption: { value: '' },
             forceDocument: { value: false },
@@ -63,6 +64,12 @@
             style="width: 60%"
             ng-model="config"
         />
+    </div>
+    <div class="form-row">
+        <label for="node-input-debug">
+            <i class="fa fa-bug"></i> Debug
+        </label>
+        <input type="checkbox" id="node-input-debug" ng-model="debug" />
     </div>
     <div class="form-row">
         <label for="node-input-chatId">
@@ -318,6 +325,7 @@
 
 <script type="text/html" data-help-name="send-files">
     <p>The <b>send-files</b> node allows you to send files to a Telegram chat or user using the Telegram API. It supports a wide range of parameters, including file attributes, captions, buttons, and scheduling options.</p>
+    <p>When the <b>Debug</b> option is enabled the node logs incoming and outgoing messages.</p>
 
     <h3>Inputs</h3>
     <dl class="message-properties">

--- a/nodes/send-file.js
+++ b/nodes/send-file.js
@@ -2,9 +2,14 @@ module.exports = function (RED) {
     function SendFile(config) {
         RED.nodes.createNode(this, config);
         this.config = RED.nodes.getNode(config.config);
+        this.debugEnabled = config.debug;
         var node = this;
 
         this.on('input', async function (msg) {
+            const debug = node.debugEnabled || msg.debug;
+            if (debug) {
+                node.log('send-files input: ' + JSON.stringify(msg));
+            }
             const chatId = msg.payload.chatId || config.chatId;
             const files = msg.payload.files || config.files.split(',').map(file => file.trim());
             const caption = msg.payload.caption || config.caption;
@@ -59,9 +64,11 @@ module.exports = function (RED) {
                 
                 // Send files
                 const response = await client.sendFile(chatId, params);
-                node.send({
-                    payload: response,
-                });
+                const out = { payload: response };
+                node.send(out);
+                if (debug) {
+                    node.log('send-files output: ' + JSON.stringify(out));
+                }
             } catch (err) {
                 node.error('Error sending files: ' + err.message);
             }

--- a/nodes/send-message.html
+++ b/nodes/send-message.html
@@ -9,6 +9,7 @@
             chatId: { value: '' },
             message: { value: '' },
             config: { type: 'config', required: false },
+            debug: { value: false },
             parseMode: { value: 'md' }, // Default parse mode is Markdown
             schedule: { value: '' }, // Default schedule is empty
             replyTo: { value: '' }, // Reply to a message
@@ -99,6 +100,12 @@
         <i class="fa fa-gear"></i> Config
       </label>
       <input type="hidden" id="node-input-config">
+    </div>
+    <div class="form-row">
+      <label for="node-input-debug">
+        <i class="fa fa-bug"></i> Debug
+      </label>
+      <input type="checkbox" id="node-input-debug">
     </div>
   
     <div class="form-row">
@@ -214,6 +221,7 @@
 
   <script type="text/html" data-help-name="send-message">
     <p>The <b>send-message</b> node allows sending messages via Telegram using the <code>telegram</code> library. It supports various message types, formatting options, and additional features like scheduling and silent messages.</p>
+    <p>Enable the <b>Debug</b> option to log incoming and outgoing messages to the Node-RED log.</p>
 
     <h3>Inputs</h3>
     <dl class="message-properties">

--- a/nodes/send-message.js
+++ b/nodes/send-message.js
@@ -5,9 +5,14 @@ module.exports = function (RED) {
     function SendMessage(config) {
         RED.nodes.createNode(this, config);
         this.config = RED.nodes.getNode(config.config);
+        this.debugEnabled = config.debug;
         var node = this;
 
         this.on('input', async function (msg) {
+            const debug = node.debugEnabled || msg.debug;
+            if (debug) {
+                node.log('send-message input: ' + JSON.stringify(msg));
+            }
             let chatId = msg.payload.chatId || config.chatId;
             const message = msg.payload.message || config.message;
             const parseMode = msg.payload.parseMode || config.parseMode;
@@ -68,9 +73,11 @@ module.exports = function (RED) {
                     await client.sendMessage(entity, params);
                 }
 
-                node.send({
-                    payload: { response },
-                });
+                const out = { payload: { response } };
+                node.send(out);
+                if (debug) {
+                    node.log('send-message output: ' + JSON.stringify(out));
+                }
             } catch (err) {
                 node.error('Error send message: ' + err.message);
             }

--- a/test/debug-option.test.js
+++ b/test/debug-option.test.js
@@ -1,0 +1,44 @@
+const assert = require('assert');
+const proxyquire = require('proxyquire').noPreserveCache();
+
+function load() {
+  const addCalls = [];
+  const logs = [];
+  class TelegramClientStub {
+    addEventHandler(fn, event) { addCalls.push({fn, event}); }
+    removeEventHandler() {}
+  }
+  class NewMessageStub {}
+
+  let NodeCtor;
+  const configNode = { client: new TelegramClientStub() };
+  const RED = {
+    nodes: {
+      createNode(node) {
+        node._events = {};
+        node.on = (e, fn) => { node._events[e] = fn; };
+        node.log = (msg) => logs.push(msg);
+        node.send = () => {};
+      },
+      registerType(name, ctor) { NodeCtor = ctor; },
+      getNode() { return configNode; }
+    }
+  };
+
+  proxyquire('../nodes/command.js', {
+    'telegram/events': { NewMessage: NewMessageStub }
+  })(RED);
+
+  return { NodeCtor, addCalls, logs };
+}
+
+describe('Debug option', function() {
+  it('logs update and output when enabled', function() {
+    const { NodeCtor, addCalls, logs } = load();
+    const node = new NodeCtor({config:'c', command:'cmd', regex:false, debug:true});
+    const handler = addCalls[0].fn;
+    handler({ message: { message:'cmd', fromId:{userId:1} } });
+    assert(logs.some(l => l.includes('command update')));
+    assert(logs.some(l => l.includes('command output')));
+  });
+});


### PR DESCRIPTION
## Summary
- add `debug` option to all custom nodes and log input/output
- document the new feature in README and node documentation
- test the debug behavior for the command node

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6884ad7c585c833096967b0872ee1c0a