### PR TITLE
Fix debug bug and improve delete-message node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,9 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Receiver and Command nodes now remove their event listeners when closed to prevent duplicate messages after redeploys.
 
+## [1.1.10] - 2025-07-27
+### Fixed
+- Receiver node no longer fails when Debug is enabled and handles updates containing `BigInt` values.
+### Changed
+- `delete-message` now forwards the original message along with the Telegram API response.
+

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ See [docs/NODES.md](docs/NODES.md) for a detailed description of every node. Bel
 - **send-message** – sends text or media messages with rich options.
 - **send-files** – uploads one or more files with captions and buttons.
 - **get-entity** – resolves usernames, IDs or t.me links into Telegram entities.
-- **delete-message** – deletes one or more messages, optionally revoking them.
+ - **delete-message** – deletes one or more messages, optionally revoking them, and forwards the original input message with the API response.
 - **iter-dialogs** – iterates over your dialogs (chats, groups, channels).
 - **iter-messages** – iterates over messages in a chat with filtering options.
 - **promote-admin** – promotes a user to admin with configurable rights.

--- a/docs/NODES.md
+++ b/docs/NODES.md
@@ -13,7 +13,7 @@ Below is a short description of each node. For a full list of configuration opti
 | **send-message** | Sends text messages or media files to a chat. Supports parse mode, buttons, scheduling, and more. |
 | **send-files** | Uploads one or more files to a chat with optional caption, thumbnails and other parameters. |
 | **get-entity** | Resolves a username, user ID or t.me URL into a Telegram entity object. |
-| **delete-message** | Deletes one or multiple messages from a chat. Can revoke messages for all participants. |
+| **delete-message** | Deletes one or multiple messages from a chat while passing the original input message along with the API response. Can revoke messages for all participants. |
 | **iter-dialogs** | Iterates through the user’s dialogs (chats, groups, channels) and outputs the collected list. |
 | **iter-messages** | Iterates over messages in a chat with various filtering and pagination options. |
 | **promote-admin** | Grants admin rights to a user in a group or channel with configurable permissions. |

--- a/nodes/delete-message.html
+++ b/nodes/delete-message.html
@@ -82,7 +82,7 @@
         <dt>payload
             <span class="property-type">object</span>
         </dt>
-        <dd>The response from the Telegram API, confirming the deletion.</dd>
+        <dd>The response from the Telegram API, confirming the deletion. All other properties from the input message are preserved.</dd>
     </dl>
 
     <h3>Details</h3>

--- a/nodes/delete-message.js
+++ b/nodes/delete-message.js
@@ -1,3 +1,5 @@
+const util = require("util");
+
 module.exports = function (RED) {
     function DeleteMessage(config) {
         RED.nodes.createNode(this, config);
@@ -8,21 +10,21 @@ module.exports = function (RED) {
         this.on('input', async function (msg) {
             const debug = node.debugEnabled || msg.debug;
             if (debug) {
-                node.log('delete-message input: ' + JSON.stringify(msg));
+                node.log('delete-message input: ' + util.inspect(msg, { depth: null }));
             }
             const chatId = msg.payload.chatId || config.chatId;
             const messageIds = msg.payload.messageIds || config.messageIds;
-            const revoke = msg.payload.revoke || config.revoke || { revoke: true };
+            const revoke = msg.payload.revoke ?? config.revoke ?? true;
               /** @type {TelegramClient} */
             const client = msg.payload?.client ? msg.payload.client : this.config.client;
 
             try {
-                const response = await client.deleteMessages(chatId, messageIds, revoke);
+                const response = await client.deleteMessages(chatId, messageIds, { revoke });
 
-                const out = { payload: response };
+                const out = { ...msg, payload: response };
                 node.send(out);
                 if (debug) {
-                    node.log('delete-message output: ' + JSON.stringify(out));
+                    node.log('delete-message output: ' + util.inspect(out, { depth: null }));
                 }
             } catch (err) {
                 node.error('Error deleting message: ' + err.message);

--- a/nodes/receiver.js
+++ b/nodes/receiver.js
@@ -1,4 +1,5 @@
 const { NewMessage } = require("telegram/events");
+const util = require("util");
 
 module.exports = function (RED) {
   function Receiver(config) {
@@ -13,13 +14,13 @@ module.exports = function (RED) {
     const handler = (update) => {
         const debug = node.debugEnabled;
         if (debug) {
-            node.log('receiver update: ' + JSON.stringify(update));
+            node.log('receiver update: ' + util.inspect(update, { depth: null }));
         }
         if (update.message.fromId != null && !ignore.includes(update.message.fromId.userId.toString())) {
             const out = { payload: { update } };
             node.send(out);
             if (debug) {
-                node.log('receiver output: ' + JSON.stringify(out));
+                node.log('receiver output: ' + util.inspect(out, { depth: null }));
             }
         }
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@patricktobias86/node-red-telegram-account",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@patricktobias86/node-red-telegram-account",
-      "version": "1.1.9",
+      "version": "1.1.10",
       "license": "MIT",
       "dependencies": {
         "telegram": "^2.17.10"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patricktobias86/node-red-telegram-account",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "Node-RED nodes to communicate with GramJS.",
   "main": "nodes/config.js",
   "keywords": [

--- a/test/receiver-debug.test.js
+++ b/test/receiver-debug.test.js
@@ -1,0 +1,44 @@
+const assert = require('assert');
+const proxyquire = require('proxyquire').noPreserveCache();
+
+function load() {
+  const addCalls = [];
+  const logs = [];
+  class TelegramClientStub {
+    addEventHandler(fn, event) { addCalls.push({fn, event}); }
+    removeEventHandler() {}
+  }
+  class NewMessageStub {}
+
+  let NodeCtor;
+  const configNode = { client: new TelegramClientStub() };
+  const RED = {
+    nodes: {
+      createNode(node) {
+        node._events = {};
+        node.on = (e, fn) => { node._events[e] = fn; };
+        node.log = (msg) => logs.push(msg);
+        node.send = () => {};
+      },
+      registerType(name, ctor) { NodeCtor = ctor; },
+      getNode() { return configNode; }
+    }
+  };
+
+  proxyquire('../nodes/receiver.js', {
+    'telegram/events': { NewMessage: NewMessageStub }
+  })(RED);
+
+  return { NodeCtor, addCalls, logs };
+}
+
+describe('Receiver node debug with BigInt', function() {
+  it('logs update and output without throwing', function() {
+    const { NodeCtor, addCalls, logs } = load();
+    const node = new NodeCtor({config:'c', ignore:'', debug:true});
+    const handler = addCalls[0].fn;
+    assert.doesNotThrow(() => handler({ message: { fromId:{userId:1n} } }));
+    assert(logs.some(l => l.includes('receiver update')));
+    assert(logs.some(l => l.includes('receiver output')));
+  });
+});


### PR DESCRIPTION
## Summary
- avoid BigInt crash in `receiver` debug output
- preserve incoming message in `delete-message` node and log with `util.inspect`
- bump version to 1.1.10 and document changes
- add regression test for receiver debug with BigInt

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688655223454833095665ec6a7c1efcd