### PR TITLE
Preserve message properties across nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - `delete-message` now forwards the original message along with the Telegram API response.
 
+## [1.1.11] - 2025-08-04
+### Fixed
+- All nodes now preserve properties on the incoming message outside of the payload.
+

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ See [docs/NODES.md](docs/NODES.md) for a detailed description of every node. Bel
 - **promote-admin** – promotes a user to admin with configurable rights.
 - **resolve-userid** – converts a username to a numeric user ID.
 
+All nodes preserve any properties on the incoming message outside of <code>msg.payload</code>.
+
 All nodes include a <code>Debug</code> option that logs incoming and outgoing messages to the Node-RED log when enabled.
 
 ## Session management

--- a/docs/NODES.md
+++ b/docs/NODES.md
@@ -19,6 +19,7 @@ Below is a short description of each node. For a full list of configuration opti
 | **promote-admin** | Grants admin rights to a user in a group or channel with configurable permissions. |
 | **resolve-userid** | Converts a Telegram username to its numeric user ID. |
 
+All nodes forward any properties on the incoming `msg` outside of `msg.payload` unchanged.
 
 All nodes provide a **Debug** checkbox. When enabled the node will log its input and output messages to aid troubleshooting.
 

--- a/nodes/auth.js
+++ b/nodes/auth.js
@@ -58,27 +58,28 @@ module.exports = function (RED) {
                     ]
                 });
 
-                const out = {
-                    topic: "auth_success",
-                    payload: {
-                        stringSession,
-                        message: "Authorization successful!"
-                    }
-                };
-                node.send(out);
-                if (debug) {
-                    node.log('auth output: ' + JSON.stringify(out));
-                }
+                 const out = {
+                     ...msg,
+                     topic: "auth_success",
+                     payload: {
+                         stringSession,
+                         message: "Authorization successful!"
+                     }
+                 };
+                 node.send(out);
+                 if (debug) {
+                     node.log('auth output: ' + JSON.stringify(out));
+                 }
 
                 node.status({ fill: "green", shape: "dot", text: "Authenticated" });
 
             } catch (err) {
-                node.error("Authentication failed: " + err.message);
-                const out = { topic: "auth_error", payload: { error: err.message } };
-                node.send(out);
-                if (debug) {
-                    node.log('auth output: ' + JSON.stringify(out));
-                }
+                 node.error("Authentication failed: " + err.message);
+                 const out = { ...msg, topic: "auth_error", payload: { error: err.message } };
+                 node.send(out);
+                 if (debug) {
+                     node.log('auth output: ' + JSON.stringify(out));
+                 }
                 node.status({ fill: "red", shape: "ring", text: "Failed" });
             }
         });

--- a/nodes/get-entity.js
+++ b/nodes/get-entity.js
@@ -25,14 +25,14 @@ module.exports = function (RED) {
                     entity = await client.getEntity(input);
                 }
 
-                const out = { payload: { input: entity } };
+                const out = { ...msg, payload: { input: entity } };
                 node.send(out);
                 if (debug) {
                     node.log('get-entity output: ' + JSON.stringify(out));
                 }
             } catch (err) {
                 node.error('Error getting entity: ' + err.message);
-                const out = { payload: { input: null } };
+                const out = { ...msg, payload: { input: null } };
                 node.send(out);
                 if (debug) {
                     node.log('get-entity output: ' + JSON.stringify(out));

--- a/nodes/iter-dialogs.js
+++ b/nodes/iter-dialogs.js
@@ -45,7 +45,7 @@ module.exports = function (RED) {
                     dialogs[dialog.id] = dialog;
                     console.log(`${dialog.id}: ${dialog.title}`);
                 }
-                const out = { payload: { dialogs } };
+                const out = { ...msg, payload: { dialogs } };
                 node.send(out);
                 if (debug) {
                     node.log('iter-dialogs output: ' + JSON.stringify(out));

--- a/nodes/iter-messages.js
+++ b/nodes/iter-messages.js
@@ -84,8 +84,8 @@ module.exports = function (RED) {
                         console.log(message.id, message.text);
                     }
                 }
-                
-                const out = { payload: { messages } };
+
+                const out = { ...msg, payload: { messages } };
                 node.send(out);
                 if (debug) {
                     node.log('iter-messages output: ' + JSON.stringify(out));

--- a/nodes/promote-admin.js
+++ b/nodes/promote-admin.js
@@ -44,7 +44,7 @@ module.exports = function (RED) {
                     rank: rank,
                 }));
 
-                const out = { payload: { response: result } };
+                const out = { ...msg, payload: { response: result } };
                 node.send(out);
                 if (debug) {
                     node.log('promote-admin output: ' + JSON.stringify(out));

--- a/nodes/resolve-userid.js
+++ b/nodes/resolve-userid.js
@@ -30,14 +30,14 @@ module.exports = function(RED) {
                 } else if (entity?.userId) {
                     userId = entity.userId;
                 }
-                const out = { payload: { userId } };
+                const out = { ...msg, payload: { userId } };
                 node.send(out);
                 if (debug) {
                     node.log('resolve-userid output: ' + JSON.stringify(out));
                 }
             } catch (err) {
                 node.error('Error resolving username: ' + err.message);
-                const out = { payload: { userId: null } };
+                const out = { ...msg, payload: { userId: null } };
                 node.send(out);
                 if (debug) {
                     node.log('resolve-userid output: ' + JSON.stringify(out));

--- a/nodes/send-file.js
+++ b/nodes/send-file.js
@@ -64,7 +64,7 @@ module.exports = function (RED) {
                 
                 // Send files
                 const response = await client.sendFile(chatId, params);
-                const out = { payload: response };
+                const out = { ...msg, payload: response };
                 node.send(out);
                 if (debug) {
                     node.log('send-files output: ' + JSON.stringify(out));

--- a/nodes/send-message.js
+++ b/nodes/send-message.js
@@ -73,7 +73,7 @@ module.exports = function (RED) {
                     await client.sendMessage(entity, params);
                 }
 
-                const out = { payload: { response } };
+                const out = { ...msg, payload: { response } };
                 node.send(out);
                 if (debug) {
                     node.log('send-message output: ' + JSON.stringify(out));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@patricktobias86/node-red-telegram-account",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@patricktobias86/node-red-telegram-account",
-      "version": "1.1.10",
+      "version": "1.1.11",
       "license": "MIT",
       "dependencies": {
         "telegram": "^2.17.10"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patricktobias86/node-red-telegram-account",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "Node-RED nodes to communicate with GramJS.",
   "main": "nodes/config.js",
   "keywords": [

--- a/test/pass-through.test.js
+++ b/test/pass-through.test.js
@@ -1,0 +1,41 @@
+const assert = require('assert');
+const proxyquire = require('proxyquire').noPreserveCache();
+
+function setup() {
+  let NodeCtor;
+  let sent;
+  const configNode = { client: {} };
+  const RED = {
+    nodes: {
+      createNode(node) {
+        node._events = {};
+        node.on = (e, fn) => { node._events[e] = fn; };
+        node.send = (msg) => { sent = msg; };
+        node.log = () => {};
+        node.error = () => {};
+      },
+      registerType(name, ctor) { NodeCtor = ctor; },
+      getNode() { return configNode; }
+    }
+  };
+
+  proxyquire('../nodes/send-message.js', {
+    telegram: { TelegramClient: function() {} },
+    'telegram/Utils': { parseID: () => ({}) }
+  })(RED);
+
+  return { NodeCtor, getSent: () => sent };
+}
+
+describe('message property relay', function() {
+  it('keeps non-payload properties on send-message output', async function() {
+    const { NodeCtor, getSent } = setup();
+    const node = new NodeCtor({ config: 'c', file: "" });
+    const client = { sendMessage: async () => 'ok' };
+    const msg = { foo: 'bar', payload: { client, chatId: 'me', message: 'hi' } };
+    await node._events['input'](msg);
+    const out = getSent();
+    assert.strictEqual(out.foo, 'bar');
+    assert.deepStrictEqual(out.payload.response, 'ok');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure all nodes forward message properties outside of `msg.payload`
- document message passthrough behavior and bump version to 1.1.11
- add test verifying non-payload fields are preserved

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68908edf7c948330a604106241b221f5