### PR TITLE
fix(auth): emit session string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - All nodes now preserve properties on the incoming message outside of the payload.
 
+## [1.1.12] - 2025-08-06
+### Fixed
+- Auth node now emits the generated `stringSession` so it can be used by other nodes.
+

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This package contains a collection of Node‑RED nodes built on top of [GramJS](
 See [docs/NODES.md](docs/NODES.md) for a detailed description of every node. Below is a quick summary:
 
 - **config** – stores your API credentials and caches sessions for reuse.
-- **auth** – interactive login that outputs a `stringSession`.
+- **auth** – interactive login that outputs a `stringSession` (also set on `msg.stringSession`).
 - **receiver** – emits messages for every incoming update (with optional ignore list). Event listeners are cleaned up on node close so redeploys won't duplicate messages.
 - **command** – triggers when an incoming message matches a command or regex. Event listeners are removed on redeploy to prevent duplicates.
 - **send-message** – sends text or media messages with rich options.

--- a/docs/NODES.md
+++ b/docs/NODES.md
@@ -7,7 +7,7 @@ Below is a short description of each node. For a full list of configuration opti
 | Node | Description |
 |------|-------------|
 | **config** | Configuration node storing API credentials and connection options. Other nodes reference this to share a Telegram client and reuse the session. Connections are tracked in a Map with a reference count so multiple nodes can wait for the same connection. |
-| **auth** | Starts an interactive login flow. Produces a `stringSession` that can be reused with the `config` node. |
+| **auth** | Starts an interactive login flow. Produces a `stringSession` (available in both <code>msg.payload.stringSession</code> and <code>msg.stringSession</code>) that can be reused with the `config` node. |
 | **receiver** | Emits an output message for every incoming Telegram message. Can ignore specific user IDs. Event handlers are automatically removed when the node is closed. |
 | **command** | Listens for new messages and triggers when a message matches a configured command or regular expression. The event listener is cleaned up on node close to avoid duplicates. |
 | **send-message** | Sends text messages or media files to a chat. Supports parse mode, buttons, scheduling, and more. |

--- a/nodes/auth.html
+++ b/nodes/auth.html
@@ -130,6 +130,8 @@ if (typeof wait === "function") {
                 <li><code>message</code> or <code>error</code>: Additional info.</li>
             </ul>
         </dd>
+        <dt>stringSession <span class="property-type">string</span></dt>
+        <dd>A copy of the session string for easier access.</dd>
     </dl>
 
     <h3>Example</h3>

--- a/nodes/auth.js
+++ b/nodes/auth.js
@@ -49,6 +49,7 @@ module.exports = function (RED) {
                 });
 
                 const stringSession = client.session.save();
+                await client.disconnect();
 
                 console.log("Sending result to output:", {
                     stringSession,
@@ -57,19 +58,19 @@ module.exports = function (RED) {
                         { type: "session_token", text: "Copy this stringSession to use in other nodes." }
                     ]
                 });
-
-                 const out = {
-                     ...msg,
-                     topic: "auth_success",
-                     payload: {
-                         stringSession,
-                         message: "Authorization successful!"
-                     }
-                 };
-                 node.send(out);
-                 if (debug) {
-                     node.log('auth output: ' + JSON.stringify(out));
-                 }
+                const out = {
+                    ...msg,
+                    topic: "auth_success",
+                    stringSession,
+                    payload: {
+                        stringSession,
+                        message: "Authorization successful!",
+                    }
+                };
+                node.send(out);
+                if (debug) {
+                    node.log('auth output: ' + JSON.stringify(out));
+                }
 
                 node.status({ fill: "green", shape: "dot", text: "Authenticated" });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@patricktobias86/node-red-telegram-account",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@patricktobias86/node-red-telegram-account",
-      "version": "1.1.11",
+    "version": "1.1.12",
       "license": "MIT",
       "dependencies": {
         "telegram": "^2.17.10"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patricktobias86/node-red-telegram-account",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "Node-RED nodes to communicate with GramJS.",
   "main": "nodes/config.js",
   "keywords": [

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -1,0 +1,48 @@
+const assert = require('assert');
+const proxyquire = require('proxyquire').noPreserveCache();
+
+function setup() {
+  let NodeCtor;
+  let sent;
+  class TelegramClientStub {
+    constructor(session, id, hash, opts) {
+      this.session = { save: () => 'sess-string' };
+    }
+    start() { return Promise.resolve(); }
+    disconnect() { return Promise.resolve(); }
+  }
+  class StringSessionStub { constructor(str) {} }
+
+  const RED = {
+    nodes: {
+      createNode(node) {
+        node._events = {};
+        node.on = (e, fn) => { node._events[e] = fn; };
+        node.send = (msg) => { sent = msg; };
+        node.status = () => {};
+        node.log = () => {};
+        node.error = () => {};
+        node.context = () => ({ flow: { set() {}, get() {} } });
+      },
+      registerType(name, ctor) { NodeCtor = ctor; }
+    }
+  };
+
+  proxyquire('../nodes/auth.js', {
+    telegram: { TelegramClient: TelegramClientStub },
+    'telegram/sessions': { StringSession: StringSessionStub }
+  })(RED);
+
+  return { NodeCtor, getSent: () => sent };
+}
+
+describe('auth node', function() {
+  it('emits stringSession on successful auth', async function() {
+    const { NodeCtor, getSent } = setup();
+    const node = new NodeCtor({ api_id: 1, api_hash: 'hash', phoneNumber: '123' });
+    await node._events['input']({ payload: {} });
+    const out = getSent();
+    assert.strictEqual(out.stringSession, 'sess-string');
+    assert.strictEqual(out.payload.stringSession, 'sess-string');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure auth node returns stringSession and disconnects the temporary client
- document stringSession availability and expose on msg.stringSession
- add regression test verifying auth output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6890f76ebbb0833095a2e637e8522645