### PR TITLE
Add configurable message type filter to receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.16] - 2025-09-22
+### Added
+- Receiver node option to ignore configurable message types (such as videos or documents) to prevent oversized uploads.
+### Changed
+- Receiver node collects detailed media type metadata to power the new filter while keeping debug logging informative.
+
 ## [1.1.15] - 2025-09-21
 ### Added
 - Receiver node option to drop updates when media exceeds a configurable size threshold, preventing large downloads.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See [docs/NODES.md](docs/NODES.md) for a detailed description of every node. Bel
 
 - **config** – stores your API credentials and caches sessions for reuse.
 - **auth** – interactive login that outputs a `stringSession` (also set on `msg.stringSession`).
-- **receiver** – emits messages for every incoming update (with optional ignore list and media size limit). Event listeners are cleaned up on node close so redeploys won't duplicate messages.
+- **receiver** – emits messages for every incoming update (with optional ignore list, message type filter, and media size limit). Event listeners are cleaned up on node close so redeploys won't duplicate messages.
 - **command** – triggers when an incoming message matches a command or regex. Event listeners are removed on redeploy to prevent duplicates.
 - **send-message** – sends text or media messages with rich options.
 - **send-files** – uploads one or more files with captions and buttons.

--- a/docs/NODES.md
+++ b/docs/NODES.md
@@ -8,7 +8,7 @@ Below is a short description of each node. For a full list of configuration opti
 |------|-------------|
 | **config** | Configuration node storing API credentials and connection options. Other nodes reference this to share a Telegram client and reuse the session. Connections are tracked in a Map with a reference count so multiple nodes can wait for the same connection. |
 | **auth** | Starts an interactive login flow. Produces a `stringSession` (available in both <code>msg.payload.stringSession</code> and <code>msg.stringSession</code>) that can be reused with the `config` node. |
-| **receiver** | Emits an output message for every incoming Telegram message. Can ignore specific user IDs and optionally skip media above a configurable size. Event handlers are automatically removed when the node is closed. |
+| **receiver** | Emits an output message for every incoming Telegram message. Can ignore specific user IDs, skip selected message types (e.g. videos or documents), and optionally drop media above a configurable size. Event handlers are automatically removed when the node is closed. |
 | **command** | Listens for new messages and triggers when a message matches a configured command or regular expression. The event listener is cleaned up on node close to avoid duplicates. |
 | **send-message** | Sends text messages or media files to a chat. Supports parse mode, buttons, scheduling, and more. |
 | **send-files** | Uploads one or more files to a chat with optional caption, thumbnails and other parameters. |

--- a/nodes/receiver.html
+++ b/nodes/receiver.html
@@ -7,6 +7,7 @@
             name: { value: '' },
             config: { type: 'config', required: false },
             ignore: { value:""},
+            ignoreMessageTypes: { value: "" },
             debug: { value: false },
             maxFileSizeMb: { value: "" }
         },
@@ -60,6 +61,17 @@
       ></textarea>
     </div>
     <div class="form-row">
+      <label for="node-input-ignoreMessageTypes">
+        <i class="fa fa-ban"></i> Ignore message types
+      </label>
+      <textarea
+        id="node-input-ignoreMessageTypes"
+        placeholder="e.g. video, document, sticker"
+        style="width: 60%"
+      ></textarea>
+      <p class="form-tips">Separate types with commas or new lines.</p>
+    </div>
+    <div class="form-row">
       <label for="node-input-maxFileSizeMb">
         <i class="fa fa-download"></i> Max media size (MB)
       </label>
@@ -100,6 +112,11 @@
             <span class="property-type">string</span>
         </dt>
         <dd>A newline-separated list of user IDs to ignore. Messages from these users will not trigger the output.</dd>
+
+        <dt>Ignore message types
+            <span class="property-type">string</span>
+        </dt>
+        <dd>List of message or media types to skip (for example <code>video</code>, <code>document</code>, or <code>sticker</code>). Separate multiple entries with commas or new lines.</dd>
 
         <dt>Max media size (MB)
             <span class="property-type">number</span>
@@ -147,6 +164,7 @@
     <ul>
         <li>Ensure the Telegram bot has sufficient permissions to receive messages in the configured chat or channel.</li>
         <li>The <b>Ignore List</b> only filters messages based on the sender's user ID.</li>
+        <li>Use <b>Ignore message types</b> to drop updates that contain media you don't want to process, such as large videos or documents.</li>
         <li>For advanced filtering based on message content, consider chaining this node with additional processing nodes in Node-RED.</li>
     </ul>
 </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@patricktobias86/node-red-telegram-account",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@patricktobias86/node-red-telegram-account",
-      "version": "1.1.15",
+      "version": "1.1.16",
       "license": "MIT",
       "dependencies": {
         "telegram": "^2.17.10"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patricktobias86/node-red-telegram-account",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "description": "Node-RED nodes to communicate with GramJS.",
   "main": "nodes/config.js",
   "keywords": [


### PR DESCRIPTION
## Summary
- add reusable helpers to classify Telegram message and media types for receiver filtering
- expose a new "Ignore message types" setting in the receiver UI, documentation, and changelog while bumping the package version
- extend receiver unit tests to cover ignored media handling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d107759fc88328b3275fe6457503f3